### PR TITLE
fix: display help info when no args provided

### DIFF
--- a/software/usb_sniffer.c
+++ b/software/usb_sniffer.c
@@ -138,7 +138,7 @@ static void parse_command_line(int argc, char *argv[])
   };
   int last = os_opt_parse(options, argc, argv);
 
-  if (g_opt.help)
+  if (g_opt.help || last == argc)
     print_help(argv[0], options);
 
   os_check(last == argc, "malformed command line, use '-h' for more information");


### PR DESCRIPTION
before: 
![image](https://github.com/ataradov/usb-sniffer/assets/29218242/1fcaf6cd-0990-490b-93ce-eb7f05cece5a)
after:
![image](https://github.com/ataradov/usb-sniffer/assets/29218242/4a7d8cce-fdaa-4066-b8bd-03c135c3578a)
