### PR TITLE
Added support for using multiple sniffer boards

### DIFF
--- a/software/usb.c
+++ b/software/usb.c
@@ -84,7 +84,7 @@ bool usb_open(int vid, int pid)
 
     rc = libusb_get_device_descriptor(dev, &desc);
     if (rc < 0)
-      continue; // check next device on error
+      continue;
 
     if (desc.idVendor == vid && desc.idProduct == pid)
     {
@@ -92,10 +92,10 @@ bool usb_open(int vid, int pid)
 
       rc = libusb_open(dev, &handle);
       if (rc < 0)
-        continue; // check next device on error
+        continue;
 
       g_usb_handle = handle;
-      break; // only care about the first result
+      break;
     }
   }
 

--- a/software/usb.c
+++ b/software/usb.c
@@ -83,16 +83,19 @@ bool usb_open(int vid, int pid)
     struct libusb_device_descriptor desc;
 
     rc = libusb_get_device_descriptor(dev, &desc);
-    usb_check_error(rc, "libusb_get_device_descriptor()");
+    if (rc < 0)
+      continue; // check next device on error
 
     if (desc.idVendor == vid && desc.idProduct == pid)
     {
       libusb_device_handle *handle;
 
       rc = libusb_open(dev, &handle);
-      usb_check_error(rc, "libusb_open()");
+      if (rc < 0)
+        continue; // check next device on error
 
       g_usb_handle = handle;
+      break; // only care about the first result
     }
   }
 


### PR DESCRIPTION
Allows users to open multiple Wireshark instances, each with a connection to its own usb-sniffer board.

This was very simply done by checking the libusb error status, and skipping a connection attempt if one failed.

A better implementation might let users select which board they want to connect to, however I see little benefit to that, and this was much easier to implement.