### PR TITLE
Add a central makefile to build / install everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+NAME = usb_sniffer
+OUT_DIR = bin
+FIRMWARE_DIR = firmware
+FPGA_DIR = fpga
+SOFTWARE_DIR = software
+
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Linux)
+	BIN_EXT =
+	BIN_OS = linux
+	EXTCAP_PATH = ~/.local/lib/wireshark/extcap
+	UDEV_FILE = $(OUT_DIR)/90-$(NAME).rules
+else ifeq ($(UNAME), Darwin)
+	BIN_EXT =
+	BIN_OS = macos
+	EXTCAP_PATH = ~/.local/lib/wireshark/extcap
+else
+	BIN_EXT = .exe
+	BIN_OS = win
+	EXTCAP_PATH = $(APPDATA)/Wireshark/extcap/
+endif
+
+BIN = $(NAME)_$(BIN_OS)$(BIN_EXT)
+
+.PHONY: software firmware fpga install install-udev prog-init prog-eeprom prog-fpga clean
+
+all: software firmware | fpga
+
+install: software | $(EXTCAP_PATH)
+	cp $(OUT_DIR)/$(BIN) $(EXTCAP_PATH)/$(NAME)$(BIN_EXT)
+
+install-udev: | $(UDEV_FILE)
+	ifeq ($(UNAME), Linux)
+		cp $(UDEV_FILE) /etc/udev/rules.d/
+	endif
+
+prog-init: software firmware fpga
+	$(OUT_DIR)/$(BIN) --mcu-sram $(OUT_DIR)/$(NAME).bin
+	sleep 5
+	$(MAKE) prog-eeprom
+	sleep 5
+	$(MAKE) prog-fpga
+
+prog-eeprom: software firmware
+	$(OUT_DIR)/$(BIN) --mcu-eeprom $(OUT_DIR)/$(NAME).bin
+
+prog-fpga: software fpga
+	$(OUT_DIR)/$(BIN) --fpga-flash $(NAME)_impl.jed
+
+software: $(OUT_DIR)/$(BIN)
+
+firmware: $(OUT_DIR)/$(NAME).bin
+
+fpga: $(OUT_DIR)/$(NAME)_impl.jed
+
+$(EXTCAP_PATH):
+	mkdir -p $(EXTCAP_PATH)
+
+$(OUT_DIR)/$(BIN): $(SOFTWARE_DIR)/*.c $(SOFTWARE_DIR)/*.h
+	$(MAKE) -C $(SOFTWARE_DIR) BIN=$(BIN)
+	mv $(SOFTWARE_DIR)/$(BIN) $(OUT_DIR)/
+
+$(OUT_DIR)/$(NAME).bin: $(FIRMWARE_DIR)/*.c $(FIRMWARE_DIR)/*.h
+	$(MAKE) -C $(FIRMWARE_DIR) OUT=$(NAME).bin
+	mv $(FIRMWARE_DIR)/$(NAME).bin $(OUT_DIR)/
+
+$(OUT_DIR)/$(NAME)_impl.jed: $(FPGA_DIR)/*.v
+# I don't know how a jed file gets built, so just warn the user
+	echo 'FPGA source files are newer than output file! Please rebuild!'
+
+clean:
+	$(MAKE) -C $(FIRMWARE_DIR) OUT=$(NAME).bin clean
+	$(MAKE) -C $(SOFTWARE_DIR) BIN=$(BIN) clean
+	rm -f $(OUT_DIR)/$(BIN) $(OUT_DIR)/$(NAME).bin

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,6 +1,7 @@
 CFLAGS  += -mmcs51 --std-c99 --opt-code-speed --no-xinit-opt --model-large
 LDFLAGS += --code-loc 0x0000 --code-size 0x1800
 LDFLAGS += --xram-loc 0x1800 --xram-size 0x0800
+OUT = usb_sniffer.bin
 
 SRCS = \
   usb_sniffer.c \
@@ -10,15 +11,13 @@ SRCS = \
   usb_descriptors.h \
   fx2_regs.h \
 
-all: usb_sniffer.ihx usb_sniffer.bin
+all: usb_sniffer.ihx $(OUT)
 
 usb_sniffer.ihx: $(SRCS)
 	sdcc $(CFLAGS) $(LDFLAGS) usb_sniffer.c
 
-usb_sniffer.bin: usb_sniffer.ihx
-	sdobjcopy -O binary -I ihex usb_sniffer.ihx usb_sniffer.bin
+$(OUT): usb_sniffer.ihx
+	sdobjcopy -O binary -I ihex usb_sniffer.ihx $(OUT)
 
 clean:
-	rm -f usb_sniffer.asm  usb_sniffer.bin  usb_sniffer.ihx  usb_sniffer.lk  usb_sniffer.lst  usb_sniffer.map  usb_sniffer.mem  usb_sniffer.rel  usb_sniffer.rst  usb_sniffer.sym
-
-
+	rm -f $(OUT) usb_sniffer.asm   usb_sniffer.ihx  usb_sniffer.lk  usb_sniffer.lst  usb_sniffer.map  usb_sniffer.mem  usb_sniffer.rel  usb_sniffer.rst  usb_sniffer.sym

--- a/software/Makefile
+++ b/software/Makefile
@@ -55,14 +55,3 @@ clean:
 
 install: $(BIN)
 	cp $(BIN) $(EXTCAP_PATH)
-
-prog_eeprom:
-	./usb_sniffer --mcu-eeprom ../firmware/usb_sniffer.bin
-
-prog_sram:
-	./usb_sniffer --fpga-sram ../fpga/impl/usb_sniffer_impl.bit
-
-prog_flash:
-	./usb_sniffer --fpga-flash ../fpga/impl/usb_sniffer_impl.jed
-
-


### PR DESCRIPTION
Allows for building + installing all relevant files and programming the device using make from the root folder.

Also will simplify automated cross-platform builds (if they get implemented - I might submit a pr later based on this one) 

Note: I don't know how the file for the FPGA gets built, so the Makefile just prints a warning if it's out of date
Also doesn't do anything to deal w/ drivers on Windows because I'm not sure how that works either.